### PR TITLE
Relax dependencies to allow minors

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
     "description" : "Light-weight option parsing with an argv hash. No optstrings attached.",
     "main" : "./index.js",
     "dependencies" : {
-        "wordwrap" : "~0.0.2",
-        "minimist" : "~0.0.1"
+        "wordwrap" : "^0.0.2",
+        "minimist" : "^0.0.1"
     },
     "devDependencies" : {
-        "hashish": "~0.0.4",
-        "tap" : "~0.4.0"
+        "hashish": "^0.0.4",
+        "tap" : "^0.4.0"
     },
     "scripts" : {
         "test" : "tap ./test/*.js"


### PR DESCRIPTION
Relax dependencies to allow minor version upgrades.

This will allow for the `minimist@0.2.1` fix for prototype pollution:

https://github.com/substack/minimist/commit/d8f2cc97cc2569f2468ba06cdd0121290f630819